### PR TITLE
Add reversible Riot Control Turret Recipe

### DIFF
--- a/data/json/recipes/electronic/other.json
+++ b/data/json/recipes/electronic/other.json
@@ -619,6 +619,40 @@
   },
   {
     "type": "recipe",
+    "result": "bot_turret_riot",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_OTHER",
+    "skill_used": "electronics",
+    "skills_required": [ [ "mechanics", 6 ], [ "computer", 5 ] ],
+    "difficulty": 8,
+    "time": "1 h",
+    "reversible": true,
+    "decomp_learn": 8,
+    "book_learn": [ [ "recipe_lab_elec", 7 ], [ "textbook_robots", 9 ] ],
+    "using": [ [ "soldering_standard", 14 ] ],
+    "qualities": [
+      { "id": "SCREW", "level": 1 },
+      { "id": "SCREW_FINE", "level": 1 },
+      { "id": "WRENCH", "level": 2 },
+      { "id": "WRENCH_FINE", "level": 1 }
+    ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "gun_module", 1 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "m203", 6 ] ],
+      [ [ "small_storage_battery", 1 ] ],
+      [ [ "power_supply", 3 ] ],
+      [ [ "antenna", 1 ] ],
+      [ [ "robot_controls", 1 ] ],
+      [ [ "omni_wheel", 1 ] ],
+      [ [ "copbot_chassis", 1 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
     "result": "bot_turret_light",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_OTHER",


### PR DESCRIPTION
Debugged a character and disassembled Riot Control Turret to check that the recipe can be learned from disassembly, then rebuilt the Riot Control Turret and checked that there were no leftover parts.

Additional context

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR, and remove the comment blocks (surrounded with <!–– and ––>) when you are done.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary

Minor: Added Inactive Riot Control Turret Recipe

#### Purpose of change

Allow disassembly of Inactive Riot Control Turrets to achieve parity as broken Riot Control Turrets can be disassembled. Activating a turret to break it so you can disassemble it is illogical.

#### Describe the solution

Added recipe, mainly copied from Medium Turret list. Components pulled from broken version as almost all turrets use the same individual list between the two versions. Time was set to 1 hour as disassembly of Riot Control Turret is twice as long as a Medium Turret.

#### Describe alternatives you've considered

Remove ability to disassemble Riot Control Turret. (Would be very stupid, but would still achieve parity)
Have Riot Control Turret be learned from military/lab schematics. (It appears at military roadblocks, suggesting a military origin, but is crafted with police robot parts)

#### Testing

Debugged a character and disassembled Riot Control Turret to check that the recipe can be learned from disassembly, then rebuilt the Riot Control Turret and checked that there were no leftover parts. Debugged a different character and checked it could be learned from the proper books.

#### Additional context

Looking through both the disassembly and assembly also brought to my attention that Light Turrets are in a weird place. Inactive variants can be disassembled but cannot be reassembled as the only recipe for them involves using spare parts in place of the Turret Interior Chassis. Will try making a PR for this as well later.